### PR TITLE
Require GHC >= 7.4 due to Data.Monoid.<> usage

### DIFF
--- a/reform-blaze.cabal
+++ b/reform-blaze.cabal
@@ -22,7 +22,7 @@ Library
                      Text.Reform.Blaze.String
                      Text.Reform.Blaze.Text
 
-  Build-depends:     base         >4 && <5,
+  Build-depends:     base         >4.5 && <5,
                      blaze-markup >= 0.5 && < 0.8,
                      blaze-html   >= 0.5 && < 0.9,
                      reform       == 0.2.*,


### PR DESCRIPTION
I've applied [revisions on hackage](https://hackage.haskell.org/package/reform-blaze-0.2.4.1/revisions/) so a new release isn't necessary unless you want to add compatibility for older GHCs.
